### PR TITLE
Add a list of topics to the Analysis Systems and Facilities training module

### DIFF
--- a/pages/training-modules/analysis-systems-and-facilities.md
+++ b/pages/training-modules/analysis-systems-and-facilities.md
@@ -21,5 +21,14 @@ modern analysis facilities. The goal of the module will be
 to prepare the students to develop scalable, performant and innovative
 tools within the ecosystem.
 
-[Computational HEP Traineeship Summer School](https://indico.cern.ch/event/1293313/timetable/)
-on July 24‒28, 2023.
+## Topics
+
+- The scientific Python ecosystem (3.5 hours)
+- Introduction to performance tuning and optimization tools (0.5 hours)
+- Machine learning: decision trees, CNNs, graph NNs, unsupervised, and autoencoders (7 hours)
+- Columnar data analysis (3.5 hours)
+- Parallel programming (6.5 hours)
+- Analysis facilities: coffea-casa and the Analysis Grand Challenge workflow (2 hours)
+- Analysis scale-out techniques (2 hours)
+- Julia for analysis (2 hours)
+- Coding Jam: long group exercise, extended over 5 days (5.75 hours)

--- a/pages/training-modules/analysis-systems-and-facilities.md
+++ b/pages/training-modules/analysis-systems-and-facilities.md
@@ -21,6 +21,5 @@ modern analysis facilities. The goal of the module will be
 to prepare the students to develop scalable, performant and innovative
 tools within the ecosystem.
 
-Coming soon....
-
-
+[Computational HEP Traineeship Summer School](https://indico.cern.ch/event/1293313/timetable/)
+on July 24‒28, 2023.


### PR DESCRIPTION
The two completed training module outlines, [Software engineering](https://tac-hep.org/training-modules/software-engineering) and [GPU/FPGA](https://tac-hep.org/training-modules/uw-gpu-fpga), have an introductory paragraph, a course syllabus, and links to all the lecture PDFs, GitHub repos, etc. They look like semester-long (or half-semester) courses. They don't have Indico sites as far as I can see.

The Data Analysis Systems and Facilities module is a week-long event, rather than a semester-long course, and it has an [Indico page](https://indico.cern.ch/event/1293313/timetable/). The Indico page covers what a syllabus would cover and stores all of the lecture PDFs and GitHub repos, so I don't see a need to duplicate information.

Also, the introductory text that's already there is fine. (I would write something similar.) So it seems like this is everything that this page needs.